### PR TITLE
Add player game log modal to roster page

### DIFF
--- a/DH-HQ_v3.3/rosters/rosters.html
+++ b/DH-HQ_v3.3/rosters/rosters.html
@@ -119,5 +119,12 @@
 <div id="tradeSimulator">
 </div>
 </div>
+<div id="gameLogModal" class="hidden">
+  <div class="modal-content glass-panel">
+    <button class="modal-close" aria-label="Close">&times;</button>
+    <h3 class="modal-title"></h3>
+    <div class="modal-body"></div>
+  </div>
+</div>
 <script defer="True" src="../scripts/app.js?v=20250826235225"></script></body>
 </html>

--- a/DH-HQ_v3.3/scripts/app.js
+++ b/DH-HQ_v3.3/scripts/app.js
@@ -24,6 +24,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const clearFiltersButton = document.getElementById('clearFiltersButton');
         const tradeSimulator = document.getElementById('tradeSimulator');
+        const gameLogModal = document.getElementById('gameLogModal');
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
 
@@ -164,6 +165,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 if (e && e.target && e.target.blur) e.target.blur();
             });
             rosterGrid?.addEventListener('click', handleTeamSelect);
+            rosterGrid?.addEventListener('click', handlePlayerNameClick);
             mainContent?.addEventListener('click', handleAssetClickForTrade);
             compareButton?.addEventListener('click', handleCompareClick);
             clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
@@ -171,6 +173,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
             positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
             clearFiltersButton?.addEventListener('click', handleClearFilters);
+            gameLogModal?.addEventListener('click', (e) => { if (e.target === gameLogModal) closeGameLogModal(); });
+            gameLogModal?.querySelector('.modal-close')?.addEventListener('click', closeGameLogModal);
+            document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeGameLogModal(); });
         }
         
         // --- Initialization ---
@@ -440,7 +445,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 });
                 assetRow.classList.add('player-selected');
             }
-            
+
             renderTradeBlock();
         }
 
@@ -448,6 +453,58 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             state.tradeBlock = {};
             document.querySelectorAll('.player-selected').forEach(el => el.classList.remove('player-selected'));
             renderTradeBlock();
+        }
+
+        // --- Game Log Modal ---
+        function handlePlayerNameClick(e) {
+            const nameEl = e.target.closest('.player-name');
+            if (!nameEl || state.isCompareMode) return;
+            const row = nameEl.closest('.player-row');
+            if (!row) return;
+            const playerId = row.dataset.assetId;
+            const playerName = row.dataset.assetLabel;
+            if (!playerId) return;
+            openGameLogModal(playerId, playerName);
+        }
+
+        async function openGameLogModal(playerId, playerName) {
+            if (!gameLogModal) return;
+            const titleEl = gameLogModal.querySelector('.modal-title');
+            const bodyEl = gameLogModal.querySelector('.modal-body');
+            if (titleEl) titleEl.textContent = `${playerName} Logs`;
+            if (bodyEl) bodyEl.innerHTML = '<div class="text-center p-4">Loading...</div>';
+            gameLogModal.classList.remove('hidden');
+            requestAnimationFrame(() => gameLogModal.classList.add('active'));
+            const season = new Date().getFullYear();
+            try {
+                const data = await fetchWithCache(`${API_BASE}/stats/nfl/player/${playerId}?season_type=regular&season=${season}&group_by=week`);
+                renderGameLogs(data, bodyEl);
+            } catch (err) {
+                console.error('Failed to fetch game logs:', err);
+                if (bodyEl) bodyEl.innerHTML = '<div class="text-center p-4">No logs available.</div>';
+            }
+        }
+
+        function renderGameLogs(data, container) {
+            if (!container) return;
+            if (!data || Object.keys(data).length === 0) {
+                container.innerHTML = '<div class="text-center p-4">No logs available.</div>';
+                return;
+            }
+            const weeks = Object.keys(data).sort((a, b) => Number(a) - Number(b));
+            let rows = '';
+            weeks.forEach(week => {
+                const stats = data[week] || {};
+                const pts = stats.pts_ppr ?? stats.pts_half_ppr ?? stats.pts_std ?? 0;
+                rows += `<tr><td>${week}</td><td>${pts.toFixed(2)}</td></tr>`;
+            });
+            container.innerHTML = `<table class="gl-table"><thead><tr><th>Week</th><th>Pts</th></tr></thead><tbody>${rows}</tbody></table>`;
+        }
+
+        function closeGameLogModal() {
+            if (!gameLogModal) return;
+            gameLogModal.classList.remove('active');
+            setTimeout(() => gameLogModal.classList.add('hidden'), 200);
         }
 
 

--- a/DH-HQ_v3.3/styles/styles.css
+++ b/DH-HQ_v3.3/styles/styles.css
@@ -2215,3 +2215,56 @@ font-weight: 500 !important;
   /* · · Center collapse icon: forced horizontal stretch via CSS sizing + preserveAspectRatio="none" · · */
 
 
+/* Game Log Modal */
+#gameLogModal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 1000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+#gameLogModal.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+#gameLogModal .modal-content {
+  position: relative;
+  max-width: 600px;
+  width: 90%;
+  padding: 1rem;
+  transform: scale(0.95);
+  transition: transform 0.2s ease;
+}
+#gameLogModal.active .modal-content {
+  transform: scale(1);
+}
+#gameLogModal .modal-close {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  color: var(--color-text-primary);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+#gameLogModal .gl-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+#gameLogModal .gl-table th,
+#gameLogModal .gl-table td {
+  padding: 0.25rem 0.5rem;
+  text-align: left;
+}
+#gameLogModal .gl-table tr:nth-child(even) {
+  background: rgba(255,255,255,0.03);
+}
+


### PR DESCRIPTION
## Summary
- add hidden game-log modal markup to roster page
- fetch and display weekly logs when player name clicked
- style modal with glass-panel look and animated overlay

## Testing
- `node --check scripts/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd5e47788832e90435cef98a5cdd5