### PR TITLE
feat: add game logs modal on roster player names

### DIFF
--- a/DH-HQ_v3.3/rosters/rosters.html
+++ b/DH-HQ_v3.3/rosters/rosters.html
@@ -119,5 +119,12 @@
 <div id="tradeSimulator">
 </div>
 </div>
+<div id="gameLogsModal" class="hidden">
+  <div class="gl-modal-content glass-panel">
+    <button id="gameLogsClose" class="gl-close-btn" aria-label="Close">&times;</button>
+    <h3 id="gameLogsTitle" class="gl-title"></h3>
+    <div id="gameLogsBody" class="gl-body"></div>
+  </div>
+</div>
 <script defer="True" src="../scripts/app.js?v=20250826235225"></script></body>
 </html>

--- a/DH-HQ_v3.3/scripts/app.js
+++ b/DH-HQ_v3.3/scripts/app.js
@@ -26,6 +26,10 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
+        const gameLogsModal = document.getElementById('gameLogsModal');
+        const gameLogsTitle = document.getElementById('gameLogsTitle');
+        const gameLogsBody = document.getElementById('gameLogsBody');
+        const gameLogsClose = document.getElementById('gameLogsClose');
 
         // --- Menu Button ---
         const menuButton = document.getElementById('menu-button');
@@ -164,6 +168,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 if (e && e.target && e.target.blur) e.target.blur();
             });
             rosterGrid?.addEventListener('click', handleTeamSelect);
+            rosterGrid?.addEventListener('click', handlePlayerNameClick);
             mainContent?.addEventListener('click', handleAssetClickForTrade);
             compareButton?.addEventListener('click', handleCompareClick);
             clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
@@ -171,6 +176,9 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
             positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
             clearFiltersButton?.addEventListener('click', handleClearFilters);
+            gameLogsClose?.addEventListener('click', closeGameLogsModal);
+            gameLogsModal?.addEventListener('click', (e) => { if (e.target === gameLogsModal) closeGameLogsModal(); });
+            document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeGameLogsModal(); });
         }
         
         // --- Initialization ---
@@ -492,6 +500,57 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                 const pos = btn.dataset.position;
                 btn.classList.toggle('active', state.activePositions.has(pos));
             });
+        }
+
+        // --- Game Logs Modal ---
+        function handlePlayerNameClick(e) {
+            if (!e.target.classList.contains('player-name')) return;
+            const row = e.target.closest('.player-row');
+            if (!row) return;
+            e.stopPropagation();
+            const playerId = row.dataset.assetId;
+            const name = e.target.textContent.trim();
+            if (!playerId) return;
+            openGameLogsModal(playerId, name);
+        }
+
+        function closeGameLogsModal() {
+            if (!gameLogsModal) return;
+            gameLogsModal.classList.remove('show');
+            setTimeout(() => gameLogsModal.classList.add('hidden'), 200);
+        }
+
+        async function openGameLogsModal(playerId, name) {
+            if (!gameLogsModal || !gameLogsBody || !gameLogsTitle) return;
+            gameLogsTitle.textContent = `${name} - Game Logs`;
+            gameLogsBody.innerHTML = '<div class="text-sm">Loading...</div>';
+            gameLogsModal.classList.remove('hidden');
+            requestAnimationFrame(() => gameLogsModal.classList.add('show'));
+
+            const now = new Date();
+            const season = now.getMonth() >= 8 ? now.getFullYear() : now.getFullYear() - 1;
+            const url = `https://api.sleeper.com/stats/nfl/player/${playerId}?season_type=regular&season=${season}`;
+
+            try {
+                const data = await fetchWithCache(url);
+                const weeks = data?.stats || {};
+                if (!weeks || Object.keys(weeks).length === 0) {
+                    gameLogsBody.innerHTML = '<div class="text-sm text-slate-400">No data available.</div>';
+                    return;
+                }
+                let html = '<table><thead><tr><th>Week</th><th>Pts</th></tr></thead><tbody>';
+                Object.keys(weeks).sort((a,b)=>parseInt(a)-parseInt(b)).forEach(week => {
+                    const w = weeks[week];
+                    const pts = w.pts_ppr ?? w.pts_half_ppr ?? w.pts_std ?? 0;
+                    const display = typeof pts === 'number' ? pts.toFixed(2) : pts;
+                    html += `<tr><td>${week}</td><td>${display}</td></tr>`;
+                });
+                html += '</tbody></table>';
+                gameLogsBody.innerHTML = html;
+            } catch (err) {
+                console.error('Game log fetch failed', err);
+                gameLogsBody.innerHTML = '<div class="text-sm text-red-400">Failed to load logs.</div>';
+            }
         }
 
 

--- a/DH-HQ_v3.3/styles/styles.css
+++ b/DH-HQ_v3.3/styles/styles.css
@@ -2208,10 +2208,64 @@ font-weight: 500 !important;
   display: inline-block;     /* override any global svg { display:block } */
   width: 1.1em;                /* icon scales with h3 font-size */
   height: 1.1em;
-  vertical-align: middle; 
+  vertical-align: middle;
   margin-right: 0px;   /* tidy baseline */
 }
 
   /* · · Center collapse icon: forced horizontal stretch via CSS sizing + preserveAspectRatio="none" · · */
 
+
+/* === Game Logs Modal === */
+#gameLogsModal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 100;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+#gameLogsModal.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+#gameLogsModal .gl-modal-content {
+  position: relative;
+  max-width: 600px;
+  width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 1rem 1.2rem;
+  border-radius: var(--panel-border-radius);
+  transform: scale(0.95);
+  opacity: 0;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+#gameLogsModal.show .gl-modal-content {
+  transform: scale(1);
+  opacity: 1;
+}
+#gameLogsModal .gl-close-btn {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.6rem;
+  font-size: 1.2rem;
+  cursor: pointer;
+  color: var(--color-text-primary);
+}
+#gameLogsModal table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+#gameLogsModal th, #gameLogsModal td {
+  padding: 0.25rem 0.35rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-panel-border);
+}
 


### PR DESCRIPTION
## Summary
- add modal markup and styles for player game logs
- wire roster player names to fetch and display weekly logs from Sleeper
- support closing the modal via button, backdrop, or Escape key

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd5e47788832e90435cef98a5cdd5