### PR TITLE
feat: add player game log modal

### DIFF
--- a/DH-HQ_v3.3/rosters/rosters.html
+++ b/DH-HQ_v3.3/rosters/rosters.html
@@ -118,6 +118,15 @@
 </main>
 <div id="tradeSimulator">
 </div>
+<div id="gameLogModal" class="hidden">
+  <div class="gl-dialog glass-panel">
+    <div class="gl-header">
+      <h3 id="gameLogTitle"></h3>
+      <button id="gameLogClose" class="gl-close">&times;</button>
+    </div>
+    <div id="gameLogBody"></div>
+  </div>
+</div>
 </div>
 <script defer="True" src="../scripts/app.js?v=20250826235225"></script></body>
 </html>

--- a/DH-HQ_v3.3/scripts/app.js
+++ b/DH-HQ_v3.3/scripts/app.js
@@ -27,6 +27,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const mainContent = document.getElementById('content');
         const pageType = document.body.dataset.page || 'welcome';
 
+        // --- Game Log Modal Elements ---
+        const gameLogModal = document.getElementById('gameLogModal');
+        const gameLogTitle = document.getElementById('gameLogTitle');
+        const gameLogBody = document.getElementById('gameLogBody');
+        const gameLogClose = document.getElementById('gameLogClose');
+
         // --- Menu Button ---
         const menuButton = document.getElementById('menu-button');
         const dropdownMenu = document.getElementById('dropdown-menu');
@@ -165,6 +171,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             });
             rosterGrid?.addEventListener('click', handleTeamSelect);
             mainContent?.addEventListener('click', handleAssetClickForTrade);
+            rosterContainer?.addEventListener('click', handlePlayerNameClick);
             compareButton?.addEventListener('click', handleCompareClick);
             clearCompareButton?.addEventListener('click', () => handleClearCompare(true));
             positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
@@ -172,6 +179,10 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
             clearFiltersButton?.addEventListener('click', handleClearFilters);
         }
+
+        gameLogClose?.addEventListener('click', closeGameLogModal);
+        gameLogModal?.addEventListener('click', (e) => { if (e.target === gameLogModal) closeGameLogModal(); });
+        document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeGameLogModal(); });
         
         // --- Initialization ---
         document.addEventListener('DOMContentLoaded', async () => {
@@ -412,6 +423,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
         function handleAssetClickForTrade(e) {
             if (!state.isCompareMode) return;
+            if (e.target.closest('.player-name')) return;
 
             const assetRow = e.target.closest('.player-row, .pick-row');
             if (!assetRow) return;
@@ -448,6 +460,70 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             state.tradeBlock = {};
             document.querySelectorAll('.player-selected').forEach(el => el.classList.remove('player-selected'));
             renderTradeBlock();
+        }
+
+        function handlePlayerNameClick(e) {
+            const nameEl = e.target.closest('.player-name');
+            if (!nameEl) return;
+            e.stopPropagation();
+            const row = nameEl.closest('.player-row');
+            const playerId = row?.dataset.assetId;
+            if (!playerId) return;
+            openGameLogModal(playerId, nameEl.textContent.trim());
+        }
+
+        async function openGameLogModal(playerId, name) {
+            if (!gameLogModal || !gameLogTitle || !gameLogBody) return;
+            gameLogTitle.textContent = `${name} - Game Logs`;
+            gameLogBody.innerHTML = '<div style="padding:1rem;text-align:center;">Loading...</div>';
+            gameLogModal.classList.remove('hidden');
+            requestAnimationFrame(() => gameLogModal.classList.add('show'));
+            try {
+                const season = new Date().getFullYear();
+                const data = await fetchPlayerGameLogs(playerId, season);
+                renderGameLogs(data);
+            } catch (err) {
+                console.error('Failed to fetch game logs', err);
+                gameLogBody.innerHTML = '<p style="padding:1rem;text-align:center;">No logs available.</p>';
+            }
+        }
+
+        function closeGameLogModal() {
+            if (!gameLogModal) return;
+            gameLogModal.classList.remove('show');
+            setTimeout(() => gameLogModal.classList.add('hidden'), 200);
+        }
+
+        async function fetchPlayerGameLogs(playerId, season) {
+            const url = `${API_BASE}/stats/nfl/player/${playerId}?season=${season}&type=week`;
+            return await fetchWithCache(url);
+        }
+
+        function renderGameLogs(logData) {
+            if (!logData) {
+                gameLogBody.innerHTML = '<p style="padding:1rem;text-align:center;">No logs available.</p>';
+                return;
+            }
+            const weeks = Array.isArray(logData) ? logData : Object.values(logData);
+            if (!weeks.length) {
+                gameLogBody.innerHTML = '<p style="padding:1rem;text-align:center;">No logs available.</p>';
+                return;
+            }
+            weeks.sort((a,b)=>(a.week||0)-(b.week||0));
+            const table = document.createElement('table');
+            table.innerHTML = '<thead><tr><th>Week</th><th>Opp</th><th>Pts</th></tr></thead>';
+            const tbody = document.createElement('tbody');
+            weeks.forEach(w=>{
+                const week = w.week || w.week_num || w.week_number || '';
+                const opp = w.opponent || w.opp || '';
+                const pts = (w.pts_half_ppr ?? w.pts_ppr ?? w.pts_std ?? 0).toFixed(1);
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${week}</td><td>${opp}</td><td>${pts}</td>`;
+                tbody.appendChild(tr);
+            });
+            table.appendChild(tbody);
+            gameLogBody.innerHTML = '';
+            gameLogBody.appendChild(table);
         }
 
 

--- a/DH-HQ_v3.3/styles/styles.css
+++ b/DH-HQ_v3.3/styles/styles.css
@@ -2208,10 +2208,64 @@ font-weight: 500 !important;
   display: inline-block;     /* override any global svg { display:block } */
   width: 1.1em;                /* icon scales with h3 font-size */
   height: 1.1em;
-  vertical-align: middle; 
+  vertical-align: middle;
   margin-right: 0px;   /* tidy baseline */
 }
 
   /* · · Center collapse icon: forced horizontal stretch via CSS sizing + preserveAspectRatio="none" · · */
 
 
+/* ⬇︎  GAME LOG MODAL  ⬇︎ */
+#gameLogModal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+#gameLogModal.hidden { display: none; }
+#gameLogModal .gl-dialog {
+  border: 1px solid var(--color-panel-border);
+  border-radius: var(--panel-border-radius);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  box-shadow: 0 0 20px var(--color-panel-border-glow);
+  padding: 0.8rem 1rem 1rem 1rem;
+  max-width: 90%;
+  width: 600px;
+  color: var(--color-text-primary);
+  transform: scale(0.95);
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+#gameLogModal.show .gl-dialog {
+  opacity: 1;
+  transform: scale(1);
+}
+#gameLogModal .gl-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+#gameLogModal .gl-close {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+#gameLogModal table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+#gameLogModal th, #gameLogModal td {
+  padding: 0.25rem 0.5rem;
+  text-align: center;
+}
+#gameLogModal tbody tr:nth-child(odd) {
+  background: rgba(255,255,255,0.03);
+}


### PR DESCRIPTION
## Summary
- add modal to roster page to show weekly game logs
- style modal with dark glass theme
- fetch and display Sleeper game logs on player name click

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd5e47788832e90435cef98a5cdd5