### PR TITLE
Revamp game log modal chips and layout

### DIFF
--- a/DH-HQ_GML1.5/rosters/rosters.html
+++ b/DH-HQ_GML1.5/rosters/rosters.html
@@ -122,6 +122,7 @@
 <div id="game-logs-modal" class="hidden">
   <div class="modal-overlay"></div>
   <div class="modal-content glass-panel">
+    <div id="modal-position-tag" class="player-tag"></div>
     <button class="modal-close-btn">&times;</button>
     <div id="modal-header">
       <h3 id="modal-player-name">Player Game Logs</h3>

--- a/DH-HQ_GML1.5/scripts/app.js
+++ b/DH-HQ_GML1.5/scripts/app.js
@@ -32,6 +32,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const modalOverlay = document.querySelector('.modal-overlay');
         const modalPlayerName = document.getElementById('modal-player-name');
         const modalBody = document.getElementById('modal-body');
+        const modalPosTag = document.getElementById('modal-position-tag');
 
         // --- Menu Button ---
         const menuButton = document.getElementById('menu-button');
@@ -794,6 +795,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             const playerName = fullPlayer ? `${fullPlayer.first_name} ${fullPlayer.last_name}` : player.name;
 
             modalPlayerName.textContent = `${playerName}'s Game Logs`;
+            modalPosTag.textContent = player.pos;
+            modalPosTag.style.backgroundColor = TAG_COLORS[player.pos] || 'var(--pos-bn)';
             document.getElementById('modal-summary-chips').innerHTML = ''; // Clear previous chips
             modalBody.innerHTML = '<p class="text-center p-4">Loading game logs...</p>';
             openModal();
@@ -813,6 +816,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
             // Render summary chips
             const summaryChipsContainer = document.getElementById('modal-summary-chips');
+            const formatOverall = (r) => (typeof r === 'number' && r <= 999) ? `#${r}` : 'NA';
+            const formatPos = (r) => (typeof r === 'number' && r > 0) ? r : 'NA';
             summaryChipsContainer.innerHTML = `
                 <div class="summary-chip">
                     <h4>FPTS / PPG</h4>
@@ -823,19 +828,19 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
                     </div>
                 </div>
                 <div class="summary-chip">
-                    <h4>OVR RANK</h4>
+                    <h4>FPTS RK</h4>
                     <div class="chip-values">
-                        <span style="color: ${getRankColor(playerRanks.overallRank)}">${playerRanks.overallRank}</span>
+                        <span style="color: ${getRankColor(playerRanks.overallRank)}">${formatOverall(playerRanks.overallRank)}</span>
                         <span class="chip-separator">/</span>
-                        <span style="color: ${getRankColor(playerRanks.ppgOverallRank)}">${playerRanks.ppgOverallRank}</span>
+                        <span style="color: ${getRankColor(playerRanks.posRank, true)}">${player.pos}&middot;${formatPos(playerRanks.posRank)}</span>
                     </div>
                 </div>
                 <div class="summary-chip">
-                    <h4>POS RANK</h4>
+                    <h4>PPG RK</h4>
                     <div class="chip-values">
-                        <span style="color: ${getRankColor(playerRanks.posRank, true)}">${playerRanks.posRank}</span>
+                        <span style="color: ${getRankColor(playerRanks.ppgOverallRank)}">${formatOverall(playerRanks.ppgOverallRank)}</span>
                         <span class="chip-separator">/</span>
-                        <span style="color: ${getRankColor(playerRanks.ppgPosRank, true)}">${playerRanks.ppgPosRank}</span>
+                        <span style="color: ${getRankColor(playerRanks.ppgPosRank, true)}">${player.pos}&middot;${formatPos(playerRanks.ppgPosRank)}</span>
                     </div>
                 </div>
             `;
@@ -902,7 +907,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
             tableHTML += '</tbody></table>';
 
-            modalBody.innerHTML = tableHTML;
+            modalBody.innerHTML = `<div class="table-card">${tableHTML}</div>`;
         }
 
         function populateLeagueSelect(leagues) {

--- a/DH-HQ_GML1.5/styles/styles.css
+++ b/DH-HQ_GML1.5/styles/styles.css
@@ -2279,6 +2279,13 @@ font-weight: 500 !important;
   color: var(--color-text-primary);
 }
 
+#modal-position-tag {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.75rem;
+  background-color: var(--pos-bn);
+}
+
 #modal-header h3 {
   font-size: 1.25rem;
   font-weight: 700;
@@ -2289,7 +2296,15 @@ font-weight: 500 !important;
 
 #modal-body {
   color: var(--color-text-secondary);
+}
+
+#modal-body .table-card {
   overflow-x: auto;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid var(--color-panel-border);
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+  max-width: 100%;
 }
 
 #modal-body table {


### PR DESCRIPTION
## Summary
- Show player's position tag in the top-left of the game logs modal
- Replace modal summary chips with FPTS/PPG, FPTS RK, and PPG RK using new rank formatting and NA for ranks above 999
- Wrap game log table in a card container for easier styling and scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b6ce8f64832ebd6d002252dbcca5