### PR TITLE
Refine modal summary chip position rank display

### DIFF
--- a/DH-HQ_JGLM3/scripts/app.js
+++ b/DH-HQ_JGLM3/scripts/app.js
@@ -860,9 +860,10 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
                 const posTextSpan = document.createElement('span');
                 posTextSpan.className = `chip-pos-rank-label pos-color-${player.pos}`;
-                posTextSpan.textContent = `${player.pos}•`;
+                posTextSpan.textContent = `${player.pos}`;
 
                 const posRankSpan = document.createElement('span');
+                posRankSpan.className = 'chip-pos-rank-value';
                 posRankSpan.style.color = getGameLogPosRankColor(player.pos, playerRanks.posRank);
                 posRankSpan.textContent = playerRanks.posRank;
 
@@ -887,9 +888,10 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
 
                 const posTextSpan = document.createElement('span');
                 posTextSpan.className = `chip-pos-rank-label pos-color-${player.pos}`;
-                posTextSpan.textContent = `${player.pos}•`;
+                posTextSpan.textContent = `${player.pos}`;
 
                 const posRankSpan = document.createElement('span');
+                posRankSpan.className = 'chip-pos-rank-value';
                 posRankSpan.style.color = getGameLogPosRankColor(player.pos, playerRanks.ppgPosRank);
                 posRankSpan.textContent = `${playerRanks.ppgPosRank}`;
 

--- a/DH-HQ_JGLM3/styles/styles.css
+++ b/DH-HQ_JGLM3/styles/styles.css
@@ -2443,14 +2443,21 @@ font-weight: 500 !important;
     }
 
     .chip-pos-rank-label {
-        font-size: 0.7em;
+        font-size: 1em;
         font-weight: 400;
-        margin-top: 0.05rem;
+        margin-top: 0;
     }
 
     .pos-rank-container {
         display: inline-flex;
-        align-items: center;
+        align-items: flex-start;
+    }
+
+    .chip-pos-rank-value {
+        font-size: 0.65em;
+        line-height: 1;
+        margin-left: 0.05rem;
+        transform: translateY(-0.2em);
     }
 
     .pos-color-QB { color: #FFB2D8BB; }

--- a/DH-HQ_JGLM3/styles/styles.css
+++ b/DH-HQ_JGLM3/styles/styles.css
@@ -2454,10 +2454,10 @@ font-weight: 500 !important;
     }
 
     .chip-pos-rank-value {
-        font-size: 0.65em;
+        font-size: 0.75em;
         line-height: 1;
         margin-left: 0.05rem;
-        transform: translateY(-0.2em);
+        transform: translateY(-0.1em);
     }
 
     .pos-color-QB { color: #FFB2D8BB; }


### PR DESCRIPTION
## Summary
- remove bullet and show position label full size in modal summary chips
- shrink and top-align rank to appear as superscript next to position

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c32d882e58832e81f65e0f134152e5