### PR TITLE
refactor: adjust game logs modal layout

### DIFF
--- a/DH-HQ_JGLM3.17/rosters/rosters.html
+++ b/DH-HQ_JGLM3.17/rosters/rosters.html
@@ -122,15 +122,17 @@
 <div id="game-logs-modal" class="hidden">
   <div class="modal-overlay"></div>
   <div class="modal-content glass-panel">
-    <i class="fa-solid fa-circle-info modal-info-btn"></i>
     <button class="modal-close-btn">&times;</button>
     <div id="modal-header">
       <h3 id="modal-player-name">Player Game Logs</h3>
-      <div id="modal-summary-chips">
-        <!-- Summary chips will be rendered here -->
+      <div id="modal-summary-row">
+        <div id="modal-summary-chips">
+          <!-- Summary chips will be rendered here -->
+        </div>
+        <i class="fa-solid fa-circle-info modal-info-btn"></i>
       </div>
     </div>
-    <div id="modal-body">
+    <div id="modal-body" class="modal-body">
       <!-- Game logs will be rendered here -->
     </div>
     <div id="stats-key-container" class="hidden stats-key-panel">

--- a/DH-HQ_JGLM3.17/scripts/app.js
+++ b/DH-HQ_JGLM3.17/scripts/app.js
@@ -1632,10 +1632,12 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         // --- Utility Functions ---
         function openModal() {
             gameLogsModal.classList.remove('hidden');
+            statsKeyContainer.classList.add('hidden');
         }
 
         function closeModal() {
             gameLogsModal.classList.add('hidden');
+            statsKeyContainer.classList.add('hidden');
         }
 
         function setLoading(isLoading, message = 'Loading...') {

--- a/DH-HQ_JGLM3.17/styles/styles.css
+++ b/DH-HQ_JGLM3.17/styles/styles.css
@@ -2242,7 +2242,6 @@ font-weight: 500 !important;
       max-width: 90%;
       width: 600px;
       max-height: 80vh;
-      overflow-y: auto;
       transform: scale(0.95);
       opacity: 0;
       transition: transform 0.2s ease-in-out, opacity 0.2s ease-in-out;
@@ -2334,8 +2333,24 @@ font-weight: 500 !important;
     #modal-body {
       color: var(--color-text-secondary);
       overflow-x: auto;
+      overflow-y: auto;
       border-radius: 8px;
-      
+      max-height: 60vh;
+      scrollbar-width: none;
+    }
+
+    #modal-body:hover {
+      scrollbar-width: thin;
+    }
+
+    #modal-body::-webkit-scrollbar {
+      width: 0;
+      height: 0;
+    }
+
+    #modal-body:hover::-webkit-scrollbar {
+      width: 8px;
+      height: 8px;
     }
     
     .modal-body{
@@ -2406,11 +2421,17 @@ font-weight: 500 !important;
       margin-bottom: 1rem;
     }
     
-    #modal-summary-chips {
+    #modal-summary-row {
       display: flex;
       justify-content: center;
-      gap: 1rem;
+      align-items: center;
+      gap: 0.5rem;
       margin-bottom: 0.75rem;
+    }
+
+    #modal-summary-chips {
+      display: flex;
+      gap: 1rem;
       flex-wrap: nowrap;
     }
     
@@ -2498,9 +2519,6 @@ font-weight: 500 !important;
     }
 
 .modal-info-btn {
-    position: absolute;
-    top: 0.8rem;
-    right: 4.5rem;
     font-size: 1.1rem;
     color: var(--color-text-secondary);
     cursor: pointer;
@@ -2517,27 +2535,31 @@ font-weight: 500 !important;
     border-radius: var(--card-border-radius);
     padding: 1rem;
     margin-top: 1rem;
+    max-height: 20vh;
+    overflow-y: auto;
 }
 
+
 .stats-key-panel h4 {
-    font-size: 1.1rem;
+    font-size: 0.95rem;
     font-weight: 700;
     color: var(--color-text-primary);
     margin-bottom: 0.3rem;
     text-align: center;
 }
 
+
 .stats-key-panel ul {
     list-style: none;
     padding: 0.1rem;
     margin: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: 0.15rem 0.5rem;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.15rem 2rem;
 }
 
 .stats-key-panel li {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
     color: var(--color-text-secondary);
     padding: 0.25rem;
     border-radius: 4px;


### PR DESCRIPTION
## Summary
- Align game log stats info icon with summary chips and apply modal styling
- Limit modal and stats key scrolling and hide scrollbars until hovered
- Collapse stats key on modal close and reduce key text into balanced two-column layout

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3526ed120832e8fbf7a610e9bb750