### PR TITLE
Add player comparison modal to trade preview

### DIFF
--- a/DH-HQ_v3.3/scripts/app.js
+++ b/DH-HQ_v3.3/scripts/app.js
@@ -917,6 +917,7 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
               <button id="collapseTradeButton"><i class="fa-solid fa-caret-down"></i></button>
             </div>
             <div class="trade-header-right">
+              <button id="comparePlayersButton" title="Compare players"><i class="fa-solid fa-people-arrows"></i></button>
               <button id="clearTradeButton"><i class="fa fa-refresh"></i></button>
             </div>
           </div>
@@ -994,6 +995,21 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             
             tradeBody.innerHTML = bodyHtml;
 
+            // Gather up to four players for comparison and wire up the compare button
+            const selectedPlayers = [];
+            teamNames.forEach(name => {
+                (tradeData[name].assets || []).forEach(asset => {
+                    if (asset.pos && asset.pos !== 'DP' && asset.pos !== 'RDP' && selectedPlayers.length < 4) {
+                        selectedPlayers.push(asset);
+                    }
+                });
+            });
+            const compareBtn = document.getElementById('comparePlayersButton');
+            if (compareBtn) {
+                compareBtn.disabled = selectedPlayers.length < 2;
+                compareBtn.onclick = () => openPlayerCompare(selectedPlayers);
+            }
+
             // Disable/enable Clear button based on whether any assets are selected
             const clearBtn = document.getElementById('clearTradeButton');
             try {
@@ -1017,6 +1033,56 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             });
 
             mainContent.style.paddingBottom = `${tradeSimulator.offsetHeight + 20}px`;
+        }
+
+        function openPlayerCompare(players) {
+            if (!players || players.length < 2) return;
+            let modal = document.getElementById('playerCompareModal');
+            if (!modal) {
+                modal = document.createElement('div');
+                modal.id = 'playerCompareModal';
+                modal.className = 'player-compare-modal';
+                modal.innerHTML = '<div class="player-compare-content"><button class="player-compare-close">&times;</button><table class="player-compare-table"></table></div>';
+                document.body.appendChild(modal);
+                modal.querySelector('.player-compare-close').addEventListener('click', closePlayerCompare);
+                modal.addEventListener('click', e => { if (e.target === modal) closePlayerCompare(); });
+                document.addEventListener('keydown', e => { if (e.key === 'Escape') closePlayerCompare(); });
+            }
+
+            const table = modal.querySelector('.player-compare-table');
+            let headerRow = '<tr><th>Stat</th>';
+            players.forEach(p => { headerRow += `<th>${p.label}</th>`; });
+            headerRow += '</tr>';
+
+            const statRows = [
+                { label: 'FPTS PPG', keys: ['fpts_ppg','ppg','fpts_per_game'] },
+                { label: 'FPTS OVR RK', keys: ['fpts_rank','fpts_ovr_rk'] },
+                { label: 'PPG OVR RK', keys: ['ppg_rank','ppg_ovr_rk'] },
+                { label: 'FPTS POS RK', keys: ['fpts_pos_rank','fpts_ppf_pos_rk'] },
+                { label: 'PPG POS RK', keys: ['ppg_pos_rank','ppf_pos_rk'] }
+            ];
+
+            let bodyHtml = '';
+            statRows.forEach(row => {
+                bodyHtml += `<tr><td>${row.label}</td>`;
+                players.forEach(p => {
+                    const pl = state.players[p.id] || {};
+                    let val = '?';
+                    for (const k of row.keys) {
+                        if (pl[k] != null) { val = pl[k]; break; }
+                        if (pl.stats && pl.stats[k] != null) { val = pl.stats[k]; break; }
+                    }
+                    bodyHtml += `<td>${val}</td>`;
+                });
+                bodyHtml += '</tr>';
+            });
+            table.innerHTML = headerRow + bodyHtml;
+            modal.style.display = 'flex';
+        }
+
+        function closePlayerCompare() {
+            const modal = document.getElementById('playerCompareModal');
+            if (modal) modal.style.display = 'none';
         }
 
 

--- a/DH-HQ_v3.3/styles/styles.css
+++ b/DH-HQ_v3.3/styles/styles.css
@@ -885,7 +885,26 @@
             border-color: var(--color-panel-border);
             cursor: not-allowed;
             pointer-events: none;
-    }
+        }
+
+        #comparePlayersButton {
+            background: #1E1F3000;
+            color: #8787Af;
+            font-size: 0.8rem;
+            padding: 1px 6px;
+            cursor: pointer;
+            transition: all 0.2s;
+            margin-top: 5px;
+            margin-right: 3px;
+            border-radius: 6px;
+        }
+        #comparePlayersButton:disabled {
+            opacity: 0.4;
+            cursor: default;
+        }
+        #comparePlayersButton:hover:not(:disabled) {
+            color: var(--color-text-primary);
+        }
     
     /* · · ⌃ SHOW TRADE CONTAINER BUTTON · · */
         #showTradeButton {
@@ -2208,10 +2227,50 @@ font-weight: 500 !important;
   display: inline-block;     /* override any global svg { display:block } */
   width: 1.1em;                /* icon scales with h3 font-size */
   height: 1.1em;
-  vertical-align: middle; 
+  vertical-align: middle;
   margin-right: 0px;   /* tidy baseline */
 }
 
   /* · · Center collapse icon: forced horizontal stretch via CSS sizing + preserveAspectRatio="none" · · */
 
 
+/* Player comparison modal */
+.player-compare-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+.player-compare-content {
+  background: var(--color-panel-bg);
+  border: 1px solid var(--color-panel-border);
+  border-radius: var(--panel-border-radius);
+  padding: 0.5rem;
+  max-width: 90%;
+  max-height: 80%;
+  overflow: auto;
+  position: relative;
+  font-size: 0.75rem;
+}
+.player-compare-table {
+  border-collapse: collapse;
+}
+.player-compare-table th,
+.player-compare-table td {
+  padding: 2px 4px;
+  text-align: center;
+  white-space: nowrap;
+}
+.player-compare-close {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  background: transparent;
+  border: none;
+  color: #8787Af;
+  cursor: pointer;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- add compare players button and modal in trade preview
- limit comparison to four players with stat-by-stat table
- style comparison modal and control button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c40f852470832eaee9362c135eec64