### PR TITLE
Fix player comparison modal overflow and alignment

### DIFF
--- a/DH-HQ_J4.2B/scripts/app.js
+++ b/DH-HQ_J4.2B/scripts/app.js
@@ -1038,8 +1038,6 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             // Summary Chips Row
             const summaryChipsRow = document.createElement('div');
             summaryChipsRow.className = 'comparison-summary-chips-row';
-            summaryChipsRow.style.gridTemplateColumns = `100px repeat(${players.length}, 1fr)`;
-            summaryChipsRow.appendChild(document.createElement('div')); // Empty cell for alignment
             players.forEach(player => {
                 const summaryChipsContainer = document.createElement('div');
                 summaryChipsContainer.className = 'summary-chips-container';

--- a/DH-HQ_J4.2B/styles/styles.css
+++ b/DH-HQ_J4.2B/styles/styles.css
@@ -2243,6 +2243,9 @@ font-weight: 500 !important;
       transform: scale(0.95);
       opacity: 0;
       transition: transform 0.2s ease-in-out, opacity 0.2s ease-in-out;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
     }
     
     #game-logs-modal:not(.hidden) .modal-content, #player-comparison-modal:not(.hidden) .modal-content {
@@ -2328,37 +2331,34 @@ font-weight: 500 !important;
       text-align: center;
     }
     
-    #modal-body {
-      color: #8086b0;
-      overflow-x: auto;
-      overflow-y: auto;
-      border-radius: 8px;
-      max-height: 60vh;
-      scrollbar-width: none;
-    }
-
-    #modal-body:hover {
-      scrollbar-width: thin;
-    }
-
-    #modal-body::-webkit-scrollbar {
-      width: 0;
-      height: 0;
-    }
-
-    #modal-body:hover::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-    }
-    
     /* · · Table Styling · · */
     .modal-body{
         position: relative;
+        flex: 1 1 auto;
+        color: #8086b0;
+        overflow-x: auto;
+        overflow-y: auto;
+        max-height: 60vh;
         background: rgba(5, 0, 30, 0.081);
         backdrop-filter: blur(1px) saturate(140%);
         border: 1px solid rgba(250, 250, 250, 0.1);
         border-radius: 9px;
         box-shadow: 0 8px 32px rgba(31, 38, 105, 0.15), inset 0 6px 20px rgba(255, 255, 255, 0.013);
+        scrollbar-width: none;
+    }
+
+    .modal-body:hover {
+        scrollbar-width: thin;
+    }
+
+    .modal-body::-webkit-scrollbar {
+        width: 0;
+        height: 0;
+    }
+
+    .modal-body:hover::-webkit-scrollbar {
+        width: 8px;
+        height: 8px;
     }
 
     .modal-body::after {
@@ -2663,11 +2663,18 @@ font-weight: 500 !important;
     gap: 0.5rem;
 }
 
-.comparison-header-row, .comparison-summary-chips-row {
+.comparison-header-row {
     display: grid;
     grid-template-columns: 100px repeat(4, 1fr);
     gap: 0.5rem;
     align-items: center;
+}
+
+.comparison-summary-chips-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
 }
 
 .player-header {
@@ -2689,6 +2696,7 @@ font-weight: 500 !important;
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
+    align-items: center;
 }
 
 .player-comparison-table {
@@ -2782,6 +2790,7 @@ font-weight: 500 !important;
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;
+        justify-content: center;
     }
 
     #player-comparison-modal .summary-chips-container {


### PR DESCRIPTION
## Summary
- Ensure player comparison modal body scrolls within container and header/footer stay in view.
- Center summary chips and allow wrapping for consistent layout across devices.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fa370888832eb9ee7efe59b08630