### PR TITLE
Fix comparison modal overflow and chip alignment

### DIFF
--- a/DH-HQ_J4.2B/scripts/app.js
+++ b/DH-HQ_J4.2B/scripts/app.js
@@ -1038,8 +1038,6 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
             // Summary Chips Row
             const summaryChipsRow = document.createElement('div');
             summaryChipsRow.className = 'comparison-summary-chips-row';
-            summaryChipsRow.style.gridTemplateColumns = `100px repeat(${players.length}, 1fr)`;
-            summaryChipsRow.appendChild(document.createElement('div')); // Empty cell for alignment
             players.forEach(player => {
                 const summaryChipsContainer = document.createElement('div');
                 summaryChipsContainer.className = 'summary-chips-container';

--- a/DH-HQ_J4.2B/styles/styles.css
+++ b/DH-HQ_J4.2B/styles/styles.css
@@ -2350,7 +2350,30 @@ font-weight: 500 !important;
       width: 8px;
       height: 8px;
     }
-    
+
+    #player-comparison-modal .modal-body {
+      color: #8086b0;
+      overflow-x: auto;
+      overflow-y: auto;
+      border-radius: 8px;
+      max-height: 60vh;
+      scrollbar-width: none;
+    }
+
+    #player-comparison-modal .modal-body:hover {
+      scrollbar-width: thin;
+    }
+
+    #player-comparison-modal .modal-body::-webkit-scrollbar {
+      width: 0;
+      height: 0;
+    }
+
+    #player-comparison-modal .modal-body:hover::-webkit-scrollbar {
+      width: 8px;
+      height: 8px;
+    }
+
     /* · · Table Styling · · */
     .modal-body{
         position: relative;
@@ -2663,10 +2686,18 @@ font-weight: 500 !important;
     gap: 0.5rem;
 }
 
-.comparison-header-row, .comparison-summary-chips-row {
+.comparison-header-row {
     display: grid;
     grid-template-columns: 100px repeat(4, 1fr);
     gap: 0.5rem;
+    align-items: center;
+}
+
+.comparison-summary-chips-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
     align-items: center;
 }
 
@@ -2689,6 +2720,7 @@ font-weight: 500 !important;
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
+    align-items: center;
 }
 
 .player-comparison-table {
@@ -2781,6 +2813,7 @@ font-weight: 500 !important;
     #player-comparison-modal .comparison-summary-chips-row {
         display: flex;
         flex-wrap: wrap;
+        justify-content: center;
         gap: 0.5rem;
     }
 


### PR DESCRIPTION
## Summary
- Ensure comparison modal body scrolls so stat table stays within bounds
- Center comparison summary chips using flex layout

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*
- `node --check DH-HQ_J4.2B/scripts/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5fa370888832eb9ee7efe59b08630